### PR TITLE
fix cursor disappear issue #15

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -72,6 +72,9 @@ export class Actions implements Disposable {
       this.win.valid && this.win.close(true)
       this.win = undefined
       if (this.guiCursor && workspace.getConfiguration(SETTING_SECTION).get('hideCursor', true)) {
+        if (gte(workspace.env.version, '0.5.0')) {
+          this.nvim.setOption('guicursor', `${this.guiCursor},a:ver1-Cursor/lCursor`)
+        }
         this.nvim.setOption('guicursor', this.guiCursor)
         this.guiCursor = ''
       }


### PR DESCRIPTION
For neovim 0.5.0 need to set `a:ver1-Cursor/lCursor` before restore guiCursor value.
#4 should also be fixed by this PR. 