### PR TITLE
fix: getCodeActions with cancel token

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -1,5 +1,5 @@
 import {Window, Buffer, Disposable, Neovim, workspace, diagnosticManager, languages, CodeAction, commands, services} from "coc.nvim"
-import {CodeActionContext, ExecuteCommandParams, Range } from "vscode-languageserver-protocol"
+import {CancellationTokenSource, CodeActionContext, ExecuteCommandParams, Range} from "vscode-languageserver-protocol"
 import gte from "semver/functions/gte"
 
 const SETTING_SECTION = 'coc-actions'
@@ -242,7 +242,9 @@ export class Actions implements Disposable {
     }
     let diagnostics = diagnosticManager.getDiagnosticsInRange(doc.textDocument, range)
     let context: CodeActionContext = { diagnostics }
-    let codeActionsMap = await languages.getCodeActions(doc.textDocument, range, context)
+    let source = new CancellationTokenSource()
+    // @ts-ignore
+    let codeActionsMap = await languages.getCodeActions(doc.textDocument, range, context, source.token)
     if (!codeActionsMap) return []
     let codeActions: CodeAction[] = []
     for (let clientId of codeActionsMap.keys()) {


### PR DESCRIPTION
coc has changed getCodeActions https://github.com/neoclide/coc.nvim/commit/2ddc477a95a8b0c83270e0feaeb589d36c53b2f2#diff-afa77f4a54ecc110291b19f59e543df7L369